### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/src/js/nvd3/LICENSE.md
+++ b/src/js/nvd3/LICENSE.md
@@ -1,5 +1,5 @@
 
-##nvd3.js License
+## nvd3.js License
 
 Copyright (c) 2011, 2012 [Novus Partners, Inc.][novus]
 
@@ -19,7 +19,7 @@ limitations under the License.
 
 
 
-##d3.js License
+## d3.js License
 
 Copyright (c) 2012, Michael Bostock
 All rights reserved.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
