### PR TITLE
Fix api authentication

### DIFF
--- a/app/api/.htaccess
+++ b/app/api/.htaccess
@@ -10,3 +10,5 @@
     # Change below before deploying to production
     RewriteRule ^(.*)$ index.php [QSA,L]
 </IfModule>
+# apache does not return auth header under normal operation, the below will set that header into a new "HTTP_AUTHORIZATION" header for consumption in PHP
+SetEnvIf Authorization .* HTTP_AUTHORIZATION=$0


### PR DESCRIPTION
API auth appears to be broken for Apache users in the latest version. 

This PR fixes compatibility with the old style API key (is still used under the system settings) and also updates the .htaccess file for the API so that apache passes the header into PHP properly. 